### PR TITLE
Fix view bounds

### DIFF
--- a/library/src/com/pascalwelsch/holocircularprogressbar/HoloCircularProgressBar.java
+++ b/library/src/com/pascalwelsch/holocircularprogressbar/HoloCircularProgressBar.java
@@ -345,7 +345,7 @@ public class HoloCircularProgressBar extends View {
             computeInsets(width - diameter, height - diameter);
         }
 
-        setMeasuredDimension(diameter, diameter);
+        setMeasuredDimension(width, height);
 
         final float halfWidth = diameter * 0.5f;
 


### PR DESCRIPTION
There is a a problem with how the view sets its dimensions in onMeasure. It's actually a simple one-liner that fixes that for me.
Here are the before and after screenshots of the view's behaviour:
before:
![circularprogressbar_boundsfixpr_before](https://cloud.githubusercontent.com/assets/1526877/4679829/60247380-5605-11e4-9da1-1df76de94fd2.png)
after:
![circularprogressbar_boundsfixpr_after](https://cloud.githubusercontent.com/assets/1526877/4679830/60247b96-5605-11e4-825b-15dd8e392239.png)

the modified sample layout file (activity_home.xml) I've used:
http://paste.kde.org/pfhl88x6e
